### PR TITLE
Use Git tag as NPM published version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             name: Publish to NPM
             command: |
               npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
-              npm publish
+              npm publish --tag $CIRCLE_TAG
 
 workflows:
   tagged-build:


### PR DESCRIPTION
## Description
> As a developer, I need to ensure the NPM package is published with a semantic version, supplied by a release.