### PR TITLE
Fix default StyleLint configuration and ignore filepaths & Uncaught Runtime Overlay Errors

### DIFF
--- a/configuration/tools/.stylelintignore
+++ b/configuration/tools/.stylelintignore
@@ -1,4 +1,6 @@
-**/*.css
+assets/dist/**/*.css
 assets/dist/**/*.js
+dist/**/*.css
 dist/**/*.js
+vendor/**/*.css
 vendor/**/*.js

--- a/src/components/profiles/development.js
+++ b/src/components/profiles/development.js
@@ -32,7 +32,7 @@ module.exports = (configuration) => {
       ...devServerSettings,
       client: {
         ...devServerSettings.client,
-        overlay: { warnings: false, errors: true }
+        overlay: { warnings: false, errors: true, runtimeErrors: false }
       },
       headers: {
         'Access-Control-Allow-Origin': '*'

--- a/src/environment/standard.js
+++ b/src/environment/standard.js
@@ -31,6 +31,10 @@ const sourcePath = pathResolver.toCallingPackage(path.join(assetRelativePathToRo
 const sourceRelativePathToRoot = path.join(assetRelativePathToRoot, 'src') + '/';
 const staticAssetOutputName = kanopiPackConfig?.filePatterns?.staticAssetOutputName ?? '[name].[hash][ext][query]';
 
+const useSass = kanopiPackConfig?.styles?.useSass ?? true;
+const defaultStyleLintConfiguration = pathResolver.toKanopiPack(path.join('..', 'configuration', 'tools', 'stylelint.config.js'));
+const defaultStyleLintIgnore = pathResolver.toKanopiPack(path.join('..', 'configuration', 'tools', '.stylelintignore'));
+
 const {
   configuration: developmentConfiguration,
   paths: {
@@ -100,9 +104,9 @@ module.exports = {
     scssIncludes: kanopiPackConfig?.styles?.scssIncludes ?? [],
     styleLintAutoFix: kanopiPackConfig?.styles?.styleLintAutoFix ?? true,
     styleLintConfigBaseDir: kanopiPackConfig?.styles?.styleLintConfigBaseDir ?? pathResolver.toKanopiPack(''),
-    styleLintConfigFile: kanopiPackConfig?.styles?.styleLintConfigFile ?? pathResolver.toKanopiPack(path.join('configuration', 'tools', 'stylelint.config.js')),
-    styleLintIgnorePath: kanopiPackConfig?.styles?.styleLintIgnorePath ?? pathResolver.toKanopiPack(path.join('configuration', 'tools', '.stylelintignore')),
-    useSass: kanopiPackConfig?.styles?.useSass ?? true
+    styleLintConfigFile: kanopiPackConfig?.styles?.styleLintConfigFile ?? defaultStyleLintConfiguration,
+    styleLintIgnorePath: kanopiPackConfig?.styles?.styleLintIgnorePath ?? defaultStyleLintIgnore,
+    useSass: useSass
   },
   watchOptions: kanopiPackConfig?.devServer?.watchOptions ?? {}
 }


### PR DESCRIPTION
## Description

During the 2.3.3 update there were configuration paths changes, which caused a regression with the default StyleLint configuration file paths.

Additionally, there are some instances of external scripts throwing uncaught exceptions which trigger the overlay for Webpack Dev Server. To avoid this, turn off runtimeErrors for the Dev Server overlay.

## Issues

Addresses issue #45 


## Steps to Validate

1. Pull the branch into an existing project `npm i -D git://github.com/kanopi/kanopi-pack.git#feature/issue-45`
2. With a project using the default/unset StyleLint configuration and exclusion paths (you may need to comment out/remove `styles.styleLintConfigFile` and `styles.styleLintIgnorePath`), ensure StyleLine loads and runs on the project CSS/SASS files
3. Make sure to restart any running Dev or Prod build so the configuration changes take effect
4. With Dev Server running, check a project where an Overlay was being triggered with a ResizeObserver exception. This seems to occur with Gravity Forms and some Block Editor instances with slow loading or rewritten images