### PR TITLE
TW29597330 Update stylelint and readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,9 +35,9 @@ Since this is a wrapper for Webpack, if you are already using Webpack or similar
 
 ## How Kanopi Pack?
 
-Kanopi Pack is installed via NPM anywhere in your project structure. 
+Kanopi Pack is installed via NPM anywhere in your project structure.
 
-### Installation 
+### Installation
 
 ```
 npm i @kanopi/pack
@@ -59,20 +59,20 @@ Configuration is implemented via the Main Configuration File, with Preferred loc
 
 ### Dependency Limitations
 
-| Package                  | Version | Notes                                                                                                                  | 
+| Package                  | Version | Notes                                                                                                                  |
 |:-------------------------|:--------|:-----------------------------------------------------------------------------------------------------------------------|
 | Chalk                    | 4.x     | Chalk v5.x uses ESM which is not compatible with the rest of the Node modules used here, it is locked at v4.x for now. |
 | Commander                | 11.x    | There are some API changes which require further evaluation outside of a standard update.                              |
-| StyleLint                | 15.x    | Other Stylelint packages are restricted to 15.x maximum currently, will reevaluate in future cycles.                   | 
+| StyleLint                | 15.x    | Other Stylelint packages are restricted to 15.x maximum currently, will reevaluate in future cycles.                   |
 | StyleLint Webpack Plugin | 4.x     | StyleLint 16.x and Node 18.x support, keeping back due to StyleLint version limitations                                |
 | Webpack Dev Server       | 4.x     | Dev Server API changes with version 5.x, requires evaluation outside of a standard maintenance cycle.                  |
 
 
 ### Platform Software Requirements
 
-| Package | Minimum | Recommended | 
+| Package | Minimum | Recommended |
 |:--------|:--------|:------------|
-| Node    | 18.x    | 20.x        |
+| Node    | 22.x    | 22.x        |
 | NPM     | 9.x     | 10.x         |
 
 ### Dependent Packages

--- a/configuration/tools/stylelint.config.js
+++ b/configuration/tools/stylelint.config.js
@@ -6,19 +6,10 @@ module.exports = {
     "at-rule-no-unknown": null,
     "at-rule-no-vendor-prefix": true,
     "block-no-empty": true,
-    "block-opening-brace-space-before": "always",
-    "color-hex-case": "lower",
     "color-hex-length": "long",
     "color-named": ["never", { ignore: "inside-function" }],
     "color-no-invalid-hex": true,
-    "declaration-bang-space-after": "never",
-    "declaration-bang-space-before": "always",
-    "declaration-block-semicolon-newline-after": "always",
-    "declaration-block-semicolon-space-before": "never",
     "declaration-block-single-line-max-declarations": 1,
-    "declaration-block-trailing-semicolon": "always",
-    "declaration-colon-space-after": "always-single-line",
-    "declaration-colon-space-before": "never",
     "declaration-property-value-disallowed-list": {
       "border": ["none"],
       "border-top": ["none"],
@@ -26,10 +17,7 @@ module.exports = {
       "border-bottom": ["none"],
       "border-left": ["none"]
     },
-    "function-comma-space-after": "always-single-line",
-    "function-parentheses-space-inside": "never",
     "function-url-quotes": "always",
-    "indentation": "tab",
     "length-zero-no-unit": true,
     "max-nesting-depth": [
       10,
@@ -43,10 +31,6 @@ module.exports = {
       }
     ],
     "media-feature-name-no-vendor-prefix": true,
-    "media-feature-parentheses-space-inside": "never",
-    "no-missing-end-of-source-newline": true,
-    "number-leading-zero": "always",
-    "number-no-trailing-zeros": true,
     "property-no-unknown": true,
     "property-no-vendor-prefix": null,
     "rule-empty-line-before": [
@@ -63,7 +47,6 @@ module.exports = {
           "Selector should be written in lowercase with hyphens and/or underscores (selector-class-pattern)"
       }
     ],
-    "selector-list-comma-newline-after": "always",
     "selector-max-compound-selectors": 10,
     "selector-max-id": 1,
     "selector-no-qualifying-type": null,
@@ -71,7 +54,6 @@ module.exports = {
     "selector-pseudo-element-colon-notation": "double",
     "selector-pseudo-element-no-unknown": null,
     "shorthand-property-no-redundant-values": true,
-    "string-quotes": "single",
     "value-no-vendor-prefix": true
   }
 };


### PR DESCRIPTION
## Description
Teamwork Ticket(s): [Monthly Kanopi Pack Maintenance: update packages, including dependabots.](https://kanopi.teamwork.com/app/tasks/29597330)

> As a developer, I need to remove deprecated stylelint and update readme npm version.

## Steps to Validate
1. Use the feature branch to update your projects dependencies, add it `npm i https://github.com/kanopi/kanopi-pack.git#hotfix/august-24-stylelint`
3. Run the Development command: `npm run development`, verify it builds the bundle and continues to listen without crashing.
4. No deprecated warnings
5. Load a page on the site using the assets 
6. Change an asset file, CSS, JS, etc and verify the command line shows the bundle rebuild (it will take about the same time production takes to build)
7. Refresh the page and verify the changes show
8. Run `npm run production` and load the site in Production mode. Verify site works as expected.

## Affected URL
test locally